### PR TITLE
Integrate Ansible

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.70.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:LKnWZnujHcQPm3MAk4elP3H9VXNjlO6rNqlO5s330Yg=",
+    "zh:09cbec93c324e6f03a866244ecb2bae71fdf1f5d3d981e858b745c90606b6b6d",
+    "zh:19685d9f4c9ddcfa476a9a428c6c612be4a1b4e8e1198fbcbb76436b735284ee",
+    "zh:3358ee6a2b24c982b7c83fac0af6898644d1bbdabf9c4e0589e91e427641ba88",
+    "zh:34f9f2936de7384f8ed887abdbcb54aea1ce7b0cf2e85243a3fd3904d024747f",
+    "zh:4a99546cc2140304c90d9ccb9db01589d4145863605a0fcd90027a643ea3ec5d",
+    "zh:4da32fec0e10dab5aa3dea3c9fe57adc973cc73a71f5d59da3f65d85d925dc3f",
+    "zh:659cf94522bc38ce0af70f7b0371b2941a0e0bcad02d17c1a7b264575fe07224",
+    "zh:6f1c172c9b98bc86e4f0526872098ee3246c2620f7b323ce0c2ce6427987f7d2",
+    "zh:79bf8fb8f37c308742e287694a9de081ff8502b065a390d1bcfbd241b4eca203",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b7a5e1dfd9e179d70a169ddd4db44b56da90309060e27d36b329fe5fb3528e29",
+    "zh:c2cc728cb18ffd5c4814a10c203452c71f5ab0c46d68f9aa9183183fa60afd87",
+    "zh:c89bb37d2b8947c9a0d62b0b86ace51542f3327970f4e56a68bf81d9d0b8b65b",
+    "zh:ef2a61e8112c3b5e70095508aadaadf077e904b62b9cfc22030337f773bba041",
+    "zh:f714550b858d141ea88579f25247bda2a5ba461337975e77daceaf0bb7a9c358",
+  ]
+}

--- a/Ansible/ansible.cfg
+++ b/Ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory = ./inventory.ini

--- a/Ansible/ansible.cfg
+++ b/Ansible/ansible.cfg
@@ -2,6 +2,7 @@
 inventory = ./aws_ec2.yml
 private_key_file = ~/.ssh/Ansible
 remote_user = ubuntu
+host_key_checking = False
 
 [inventory]
 # List of enabled inventory plugins, it also determines the order in which they are used.

--- a/Ansible/ansible.cfg
+++ b/Ansible/ansible.cfg
@@ -1,2 +1,8 @@
 [defaults]
-inventory = ./inventory.ini
+inventory = ./aws_ec2.yml
+private_key_file = ~/.ssh/Ansible
+remote_user = ubuntu
+
+[inventory]
+# List of enabled inventory plugins, it also determines the order in which they are used.
+enable_plugins = host_list, script, auto, yaml, ini, toml, aws_ec2

--- a/Ansible/aws_ec2.yml
+++ b/Ansible/aws_ec2.yml
@@ -1,0 +1,19 @@
+plugin: aws_ec2
+aws_profile: default
+regions:
+  - us-east-1
+filters:
+  instance-state-name: running
+keyed_groups:
+  - prefix: Tag
+    key: tags
+groups:
+  frontend: "'public' in tags.Privacy"
+  backend: "'private' in tags.Privacy"
+hostnames:
+  - tag:Name
+compose:
+  ansible_host: public_ip_address if tags.Name == "bastion" else private_ip_address
+  ansible_ssh_common_args: >
+    '-o ProxyCommand="ssh -W %h:%p ubuntu@18.232.129.229"'
+    if tags.Name != "bastion" else ''

--- a/Ansible/aws_ec2.yml
+++ b/Ansible/aws_ec2.yml
@@ -1,18 +1,28 @@
 plugin: aws_ec2
+
 aws_profile: default
+
 regions:
   - us-east-1
+
 filters:
   tag:Team: team-1
   instance-state-name: running
+
 keyed_groups:
   - prefix: Tag
     key: tags
+
 groups:
   frontend: "'public' in tags.Privacy"
   backend: "'private' in tags.Privacy"
+  jenkins_masters: "'master' in tags.Jenkins"
+  jenkins_workers: "'worker' in tags.Jenkins"
+#  local:
+
 hostnames:
   - tag:Name
+  
 compose:
   ansible_host: public_ip_address if tags.Name == "bastion" else private_ip_address
   ansible_ssh_common_args: >

--- a/Ansible/aws_ec2.yml
+++ b/Ansible/aws_ec2.yml
@@ -3,6 +3,7 @@ aws_profile: default
 regions:
   - us-east-1
 filters:
+  tag:Team: team-1
   instance-state-name: running
 keyed_groups:
   - prefix: Tag
@@ -15,5 +16,5 @@ hostnames:
 compose:
   ansible_host: public_ip_address if tags.Name == "bastion" else private_ip_address
   ansible_ssh_common_args: >
-    '-o ProxyCommand="ssh -W %h:%p ubuntu@18.232.129.229"'
+    '-o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p ubuntu@{{ hostvars["bastion"]["public_ip_address"] }}"'
     if tags.Name != "bastion" else ''

--- a/Ansible/bootstrap.yml
+++ b/Ansible/bootstrap.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Update and install packages
+  hosts: all
+  become: true
+  pre_tasks:
+  
+  - name: Install updates (Ubuntu)
+    tags: always
+    apt:
+      upgrade: dist
+      update_cache: yes
+    when: ansible_distribution == "Ubuntu"
+
+
+#- name: Change hostnames to match Name tag
+#  hosts: aws_ec2
+#  gather_facts: false
+#  roles:
+#    - hostname

--- a/Ansible/helper_steps.txt
+++ b/Ansible/helper_steps.txt
@@ -1,0 +1,19 @@
+# ssh -o ProxyCommand="ssh -W %h:%p ubuntu@<BASTION_HOST_PUBLIC_IP>" ubuntu@<JENKINS_SERVER_PRIVATE_IP>
+ssh -o ProxyCommand="ssh -W %h:%p ubuntu@" ubuntu@
+
+cat /var/jenkins_home/secrets/initialAdminPassword
+
+exit
+
+# ssh -i ~/.ssh/Ansible -L 8080:<JENKINS_SERVER_PRIVATE_IP>:8080 ubuntu@<BASTION_HOST_PUBLIC_IP>
+ssh -i ~/.ssh/Ansible -L 8080::8080 ubuntu@
+
+firefox localhost:8080 &
+
+# Initial Password: <JENKINS_INITIAL_ADMIN_PASSWORD>
+Initial Password: 
+
+# Worker Node Host: <BACKEND_SERVER_PRIVATE_IP>
+Worker Node Host: 
+
+ansible all -m ansible.builtin.setup > facts.

--- a/Ansible/install_docker.yml
+++ b/Ansible/install_docker.yml
@@ -4,12 +4,11 @@
   become: true
   pre_tasks:
   
-  - name: Install updates (Ubuntu)
+  - name: Update repository index (Ubuntu)
     tags: always
     apt:
-      upgrade: dist
       update_cache: yes
-    #changed_when: false
+    changed_when: false
     when: ansible_distribution == "Ubuntu"
 
 

--- a/Ansible/install_docker.yml
+++ b/Ansible/install_docker.yml
@@ -1,0 +1,66 @@
+---
+- name: Install Docker Engine on the private instances
+  hosts: private_instances
+  become: true
+  tasks:
+
+    # Update apt package index
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
+    # Install prerequisites
+    - name: Install prerequisite packages
+      apt:
+        name: 
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - software-properties-common
+        state: present
+
+    # Add Docker’s official GPG key
+    - name: Add Docker GPG key
+      apt_key:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        state: present
+
+    # Set up Docker stable repository
+    - name: Add Docker repository
+      apt_repository:
+        repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        state: present
+
+    # Update apt cache after adding Docker repository
+    - name: Update apt cache after Docker repo
+      apt:
+        update_cache: yes
+
+    # Install Docker Engine
+    - name: Install Docker
+      apt:
+        name: docker-ce
+        state: present
+
+    # Ensure Docker service is enabled and started
+    - name: Ensure Docker is running
+      systemd:
+        name: docker
+        enabled: yes
+        state: started
+
+    # Add current user to the Docker group (optional, for non-root usage)
+    - name: Add ubuntu user to Docker group
+      user:
+        name: ubuntu
+        groups: docker
+        append: yes
+      when: ansible_user == "ubuntu"
+
+    # Verify Docker installation
+    - name: Check Docker version
+      command: docker --version
+      register: docker_version_output
+
+    - debug:
+        var: docker_version_output.stdout

--- a/Ansible/install_docker.yml
+++ b/Ansible/install_docker.yml
@@ -1,66 +1,20 @@
 ---
-- name: Install Docker Engine on the private instances
-  hosts: private_instances
+
+- hosts: all
   become: true
-  tasks:
+  pre_tasks:
+  
+  - name: Install updates (Ubuntu)
+    tags: always
+    apt:
+      upgrade: dist
+      update_cache: yes
+    #changed_when: false
+    when: ansible_distribution == "Ubuntu"
 
-    # Update apt package index
-    - name: Update apt cache
-      apt:
-        update_cache: yes
 
-    # Install prerequisites
-    - name: Install prerequisite packages
-      apt:
-        name: 
-          - apt-transport-https
-          - ca-certificates
-          - curl
-          - software-properties-common
-        state: present
-
-    # Add Docker’s official GPG key
-    - name: Add Docker GPG key
-      apt_key:
-        url: https://download.docker.com/linux/ubuntu/gpg
-        state: present
-
-    # Set up Docker stable repository
-    - name: Add Docker repository
-      apt_repository:
-        repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
-        state: present
-
-    # Update apt cache after adding Docker repository
-    - name: Update apt cache after Docker repo
-      apt:
-        update_cache: yes
-
-    # Install Docker Engine
-    - name: Install Docker
-      apt:
-        name: docker-ce
-        state: present
-
-    # Ensure Docker service is enabled and started
-    - name: Ensure Docker is running
-      systemd:
-        name: docker
-        enabled: yes
-        state: started
-
-    # Add current user to the Docker group (optional, for non-root usage)
-    - name: Add ubuntu user to Docker group
-      user:
-        name: ubuntu
-        groups: docker
-        append: yes
-      when: ansible_user == "ubuntu"
-
-    # Verify Docker installation
-    - name: Check Docker version
-      command: docker --version
-      register: docker_version_output
-
-    - debug:
-        var: docker_version_output.stdout
+- name: Install Docker Engine on the private instances
+  hosts: backend
+  become: true
+  roles:
+    - docker

--- a/Ansible/install_jenkins.yml
+++ b/Ansible/install_jenkins.yml
@@ -1,6 +1,7 @@
 ---
+
 - name: Deploy Jenkins on Docker
-  hosts: Tag_Name_private_jenkins_server
+  hosts: jenkins_masters
   become: true
   vars:
     jenkins_image: "jenkins/jenkins:lts"
@@ -12,7 +13,16 @@
 
 
 - name: Install Java on Jenkins Slave Nodes
-  hosts: Tag_Name_private_backend_server
+  hosts: jenkins_workers
   become: yes
+  pre_tasks:
+
+  - name: Update repository index (Ubuntu)
+    tags: always
+    apt:
+      update_cache: yes
+    changed_when: false
+    when: ansible_distribution == "Ubuntu"
+
   roles:
     - java

--- a/Ansible/install_jenkins.yml
+++ b/Ansible/install_jenkins.yml
@@ -1,0 +1,18 @@
+---
+- name: Deploy Jenkins on Docker
+  hosts: Tag_Name_private_jenkins_server
+  become: true
+  vars:
+    jenkins_image: "jenkins/jenkins:lts"
+    jenkins_container_name: "jenkins-server"
+    jenkins_port: 8080
+    jenkins_home: "/var/jenkins_home"
+  roles:
+    - jenkins
+
+
+- name: Install Java on Jenkins Slave Nodes
+  hosts: Tag_Name_private_backend_server
+  become: yes
+  roles:
+    - java

--- a/Ansible/inventory.ini
+++ b/Ansible/inventory.ini
@@ -1,9 +1,0 @@
-[public_instances]
-depi-frontend-server ansible_host=34.207.170.109 ansible_user=ubuntu ansible_ssh_private_key_file=/home/abdelrahman/.ssh/id_ed25519
-
-[private_instances]
-depi_backend_server ansible_host=10.0.0.91 ansible_user=ubuntu ansible_ssh_private_key_file=/home/abdelrahman/.ssh/id_ed25519
-jenkins_server_instance ansible_host=10.0.2.168 ansible_user=ubuntu ansible_ssh_private_key_file=/home/abdelrahman/.ssh/id_ed25519
-
-[all:vars]
-ansible_ssh_common_args='-o StrictHostKeyChecking=no -o ProxyCommand="ssh -W %h:%p -q -i /home/abdelrahman/.ssh/id_ed25519 ubuntu@34.207.170.109"'

--- a/Ansible/inventory.ini
+++ b/Ansible/inventory.ini
@@ -1,0 +1,9 @@
+[public_instances]
+depi-frontend-server ansible_host=34.207.170.109 ansible_user=ubuntu ansible_ssh_private_key_file=/home/abdelrahman/.ssh/id_ed25519
+
+[private_instances]
+depi_backend_server ansible_host=10.0.0.91 ansible_user=ubuntu ansible_ssh_private_key_file=/home/abdelrahman/.ssh/id_ed25519
+jenkins_server_instance ansible_host=10.0.2.168 ansible_user=ubuntu ansible_ssh_private_key_file=/home/abdelrahman/.ssh/id_ed25519
+
+[all:vars]
+ansible_ssh_common_args='-o StrictHostKeyChecking=no -o ProxyCommand="ssh -W %h:%p -q -i /home/abdelrahman/.ssh/id_ed25519 ubuntu@34.207.170.109"'

--- a/Ansible/roles/docker/tasks/main.yml
+++ b/Ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,48 @@
+- name: Install prerequisite packages
+  apt:
+    name: 
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - software-properties-common
+    state: present
+
+- name: Add Docker GPG key
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+
+- name: Add Docker repository
+  apt_repository:
+    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    state: present
+
+- name: Update apt cache after adding Docker repo
+  apt:
+    update_cache: yes
+
+- name: Install Docker
+  apt:
+    name: docker-ce
+    state: present
+
+- name: Ensure Docker is enabled and started
+  systemd:
+    name: docker
+    enabled: yes
+    state: started
+
+- name: Add ubuntu user to Docker group
+  user:
+    name: ubuntu
+    groups: docker
+    append: yes
+  when: ansible_user == "ubuntu"
+
+# Verify Docker installation
+- name: Check Docker version
+  command: docker --version
+  register: docker_version_output
+
+- debug:
+    var: docker_version_output.stdout

--- a/Ansible/roles/hostname/tasks/main.yml
+++ b/Ansible/roles/hostname/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: Gather EC2 instance facts
+  ec2_instance_info:
+    region: us-east-1
+    filters:
+      "tag:Name": "*"
+  register: ec2_instances
+
+- name: Set hostname based on Name tag
+  hostname:
+    name: "{{ item.tags.Name }}"
+  when: item.tags.Name is defined
+  loop: "{{ ec2_instances.instances }}"
+
+- name: Ensure hostname is persisted in /etc/hostname
+  lineinfile:
+    path: /etc/hostname
+    line: "{{ item.tags.Name }}"
+  when: item.tags.Name is defined
+  loop: "{{ ec2_instances.instances }}"
+
+- name: Ensure /etc/hosts is updated
+  lineinfile:
+    path: /etc/hosts
+    regexp: '^127\.0\.1\.1'
+    line: "127.0.1.1 {{ item.tags.Name }}"
+    state: present
+  when: item.tags.Name is defined
+  loop: "{{ ec2_instances.instances }}"

--- a/Ansible/roles/java/tasks/main.yml
+++ b/Ansible/roles/java/tasks/main.yml
@@ -1,11 +1,8 @@
-- name: Update APT package list (for Ubuntu)
+- name: Install fontconfig and openjdk-17-jre (Ubuntu)
   apt:
-    update_cache: yes
-  when: ansible_distribution == "Ubuntu"
-
-- name: Install OpenJDK 11 (for Ubuntu)
-  apt:
-    name: openjdk-11-jdk
+    name:
+      - fontconfig
+      - openjdk-17-jre
     state: present
   when: ansible_distribution == "Ubuntu"
 
@@ -18,3 +15,28 @@
   debug:
     msg: "{{ java_version_output.stdout }}"
   when: java_version_output is defined
+
+- name: Create Jenkins worker home directory
+  file:
+    path: "/opt/jenkins_worker"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Generate SSH key pair
+  openssh_keypair:
+    path: /root/.ssh/id_ed25519
+    type: "ed25519"
+    comment: "Jenkins worker key pair"
+  register: ssh_key
+
+#- name: Display generated public key
+#  debug:
+#    msg: "Generated public key: {{ ssh_key.public_key }}"
+
+- name: Add public key to authorized_keys
+  authorized_key:
+    user: root
+    state: present
+    key: "{{ ssh_key.public_key }}"

--- a/Ansible/roles/java/tasks/main.yml
+++ b/Ansible/roles/java/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Update APT package list (for Ubuntu)
+  apt:
+    update_cache: yes
+  when: ansible_distribution == "Ubuntu"
+
+- name: Install OpenJDK 11 (for Ubuntu)
+  apt:
+    name: openjdk-11-jdk
+    state: present
+  when: ansible_distribution == "Ubuntu"
+
+- name: Verify Java installation
+  command: java -version
+  register: java_version_output
+  ignore_errors: yes
+
+- name: Display Java version
+  debug:
+    msg: "{{ java_version_output.stdout }}"
+  when: java_version_output is defined

--- a/Ansible/roles/jenkins/tasks/main.yml
+++ b/Ansible/roles/jenkins/tasks/main.yml
@@ -15,7 +15,7 @@
     state: directory
     owner: root
     group: root
-    mode: '0755'
+    mode: '0777'
 
 - name: Run Jenkins container
   docker_container:
@@ -28,8 +28,8 @@
       - "50000:50000"
     volumes:
       - "{{ jenkins_home }}:/var/jenkins_home"
-    env:
-      JAVA_OPTS: "-Djenkins.install.runSetupWizard=false"  # Skip initial setup wizard
+#    env:
+#      JAVA_OPTS: "-Djenkins.install.runSetupWizard=false"  # Skip initial setup wizard
 
 - name: Check if Jenkins container is running
   shell: docker ps | grep "{{ jenkins_container_name }}"

--- a/Ansible/roles/jenkins/tasks/main.yml
+++ b/Ansible/roles/jenkins/tasks/main.yml
@@ -1,0 +1,40 @@
+- name: Ensure Docker is running
+  service:
+    name: docker
+    state: started
+    enabled: true
+
+- name: Pull Jenkins Docker image
+  docker_image:
+    name: "{{ jenkins_image }}"
+    source: pull
+
+- name: Create Jenkins home directory
+  file:
+    path: "{{ jenkins_home }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Run Jenkins container
+  docker_container:
+    name: "{{ jenkins_container_name }}"
+    image: "{{ jenkins_image }}"
+    state: started
+    restart_policy: always
+    ports:
+      - "{{ jenkins_port }}:8080"
+      - "50000:50000"
+    volumes:
+      - "{{ jenkins_home }}:/var/jenkins_home"
+    env:
+      JAVA_OPTS: "-Djenkins.install.runSetupWizard=false"  # Skip initial setup wizard
+
+- name: Check if Jenkins container is running
+  shell: docker ps | grep "{{ jenkins_container_name }}"
+  register: container_status
+
+- name: Show Jenkins container status
+  debug:
+    msg: "Jenkins container status: {{ container_status.stdout }}"

--- a/main.tf
+++ b/main.tf
@@ -226,7 +226,7 @@ resource "aws_instance" "depi-frontend-server" {
   instance_type          = "t2.micro"
   key_name               = aws_key_pair.ansible-public-key.id
   subnet_id              = aws_subnet.public-subnet-1.id
-  vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
+  vpc_security_group_ids = [aws_security_group.bastion_host_secuirty_group.id]
 
   tags = {
     Name = "bastion"
@@ -249,7 +249,7 @@ resource "aws_security_group" "private_app_secuirty_group" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["10.0.3.0/24", "10.0.2.0/24"]
   }
 
   # Allow Jenkins access on port 8080
@@ -257,7 +257,7 @@ resource "aws_security_group" "private_app_secuirty_group" {
     from_port   = 8080
     to_port     = 8080
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["10.0.3.0/24"]
   }
 
   # Allowing all outbounding traffic
@@ -284,6 +284,7 @@ resource "aws_instance" "jenkins_server_instance" {
 #    Role = ""
     Team = "team-1"
     Privacy = "private"
+    Jenkins = "master"
   }
 }
 
@@ -302,6 +303,7 @@ resource "aws_instance" "depi_backend_server" {
 #    Role = ""
     Team = "team-1"
     Privacy = "private"
+    Jenkins = "worker"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -277,7 +277,7 @@ resource "aws_instance" "jenkins_server_instance" {
   ami                    = "ami-005fc0f236362e99f"
   instance_type          = "t2.micro"
   key_name               = aws_key_pair.abdelrahman-public-key.id
-  subnet_id              = aws_subnet.public-subnet-3.id
+  subnet_id              = aws_subnet.private-subnet-3.id
   vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -13,9 +13,9 @@ resource "aws_s3_bucket" "terraform_backend_2" {
 }
 
 # Create an AWS keypair
-resource "aws_key_pair" "abdelrahman-public-key" {
-  key_name   = "abdelrahman-public-key"
-  public_key = file("/home/abdelrahman/.ssh/id_ed25519.pub")
+resource "aws_key_pair" "ansible-public-key" {
+  key_name   = "ansible-public-key"
+  public_key = file("/home/abdelrahman/.ssh/Ansible.pub")
 }
 
 # Create a VPC
@@ -236,7 +236,7 @@ resource "aws_security_group" "bastion_host_secuirty_group" {
 resource "aws_instance" "depi-frontend-server" {
   ami                    = "ami-005fc0f236362e99f"
   instance_type          = "t2.micro"
-  key_name               = aws_key_pair.abdelrahman-public-key.id
+  key_name               = aws_key_pair.ansible-public-key.id
   subnet_id              = aws_subnet.public-subnet-1.id
   vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 
@@ -276,7 +276,7 @@ resource "aws_security_group" "private_app_secuirty_group" {
 resource "aws_instance" "jenkins_server_instance" {
   ami                    = "ami-005fc0f236362e99f"
   instance_type          = "t2.micro"
-  key_name               = aws_key_pair.abdelrahman-public-key.id
+  key_name               = aws_key_pair.ansible-public-key.id
   subnet_id              = aws_subnet.private-subnet-3.id
   vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 
@@ -289,7 +289,7 @@ resource "aws_instance" "jenkins_server_instance" {
 resource "aws_instance" "depi_backend_server" {
   ami                    = "ami-005fc0f236362e99f"
   instance_type          = "t2.micro"
-  key_name               = aws_key_pair.abdelrahman-public-key.id
+  key_name               = aws_key_pair.ansible-public-key.id
   subnet_id              = aws_subnet.private-subnet-1.id
   vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 

--- a/main.tf
+++ b/main.tf
@@ -233,7 +233,7 @@ resource "aws_instance" "depi-frontend-server" {
 #    Service = ""
 #    Env = ""
 #    Role = ""
-#    Team = ""
+    Team = "team-1"
     Privacy = "public"
   }
 }
@@ -248,6 +248,14 @@ resource "aws_security_group" "private_app_secuirty_group" {
   ingress {
     from_port   = 22
     to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow Jenkins access on port 8080
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -274,7 +282,7 @@ resource "aws_instance" "jenkins_server_instance" {
 #    Service = ""
 #    Env = ""
 #    Role = ""
-#    Team = ""
+    Team = "team-1"
     Privacy = "private"
   }
 }
@@ -292,7 +300,7 @@ resource "aws_instance" "depi_backend_server" {
 #    Service = ""
 #    Env = ""
 #    Role = ""
-#    Team = ""
+    Team = "team-1"
     Privacy = "private"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,45 +1,30 @@
-# Terraform Configuration & AWS Provider Configuration
-
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-
-#   backend "s3" {
-#     bucket = "espace-terraform-backend-2"
-#     key    = "Terraform-Backend/terraform.tfstate"
-#     region = "us-eas-1"
-#   }
-}
+# AWS Provider Configuration
 
 provider "aws" {
   region = "us-east-1"
 }
 
-# # Create an S3 bucket
-# resource "aws_s3_bucket" "terraform_backend_2" {
-#   bucket = "espace-terraform-backend-2"
-#   tags = {
-#     Name = "terraform-backend-2"
-#   }
-# }
+# Create an S3 bucket
+resource "aws_s3_bucket" "terraform_backend_2" {
+  bucket = "espace-terraform-backend-2"
+  tags = {
+    Name = "terraform-backend-2"
+  }
+}
 
 # Create an AWS keypair
-resource "aws_key_pair" "amir-public-key" {
-  key_name   = "amir-public-key"
-  public_key = file("C:/Users/moham/.ssh/id_rsa.pub")
+resource "aws_key_pair" "abdelrahman-public-key" {
+  key_name   = "abdelrahman-public-key"
+  public_key = file("/home/abdelrahman/.ssh/id_ed25519.pub")
 }
 
 # Create a VPC
 resource "aws_vpc" "Depi_vpc" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "Depi_vpc"
-    Graduation_Project = "True"  
-    Task = "Amir Kasseb "
+    Name               = "Depi_vpc"
+    Graduation_Project = "True"
+    Task               = "Amir Kasseb "
   }
 }
 # Create Private Subnets 
@@ -47,8 +32,8 @@ resource "aws_vpc" "Depi_vpc" {
 # Private Subnet 1 
 resource "aws_subnet" "private-subnet-1" {
   availability_zone = "us-east-1a"
-  vpc_id     = aws_vpc.Depi_vpc.id
-  cidr_block = "10.0.0.0/24"
+  vpc_id            = aws_vpc.Depi_vpc.id
+  cidr_block        = "10.0.0.0/24"
   tags = {
     Name = "private-subnet-1"
   }
@@ -57,62 +42,62 @@ resource "aws_subnet" "private-subnet-1" {
 # Private Subnet 2
 resource "aws_subnet" "private-subnet-2" {
   availability_zone = "us-east-1b"
-  vpc_id     = aws_vpc.Depi_vpc.id
-  cidr_block = "10.0.1.0/24"
+  vpc_id            = aws_vpc.Depi_vpc.id
+  cidr_block        = "10.0.1.0/24"
   tags = {
-    Name = "private-subnet-2"
-    Graduation_Project = "True"  
-    Task = "Amir Kasseb "
+    Name               = "private-subnet-2"
+    Graduation_Project = "True"
+    Task               = "Amir Kasseb "
   }
 }
 
 # Private Subnet 3
 resource "aws_subnet" "private-subnet-3" {
   availability_zone = "us-east-1c"
-  vpc_id     = aws_vpc.Depi_vpc.id
-  cidr_block = "10.0.2.0/24"
+  vpc_id            = aws_vpc.Depi_vpc.id
+  cidr_block        = "10.0.2.0/24"
   tags = {
-    Name = "private-subnet-3"
-    Graduation_Project = "True"  
-    Task = "Amir Kasseb "
+    Name               = "private-subnet-3"
+    Graduation_Project = "True"
+    Task               = "Amir Kasseb "
   }
 }
 # Create Public Subnets 
 
 # Public Subnet 1 
 resource "aws_subnet" "public-subnet-1" {
-  map_public_ip_on_launch = true 
-  availability_zone = "us-east-1a"
-  vpc_id     = aws_vpc.Depi_vpc.id
-  cidr_block = "10.0.3.0/24"
+  map_public_ip_on_launch = true
+  availability_zone       = "us-east-1a"
+  vpc_id                  = aws_vpc.Depi_vpc.id
+  cidr_block              = "10.0.3.0/24"
   tags = {
-    Name = "public-subnet-1"
-    Graduation_Project = "True"  
-    Task = "Amir Kasseb "
+    Name               = "public-subnet-1"
+    Graduation_Project = "True"
+    Task               = "Amir Kasseb "
   }
 }
 
 # Public Subnet 2
 resource "aws_subnet" "public-subnet-2" {
   availability_zone = "us-east-1b"
-  vpc_id     = aws_vpc.Depi_vpc.id
-  cidr_block = "10.0.4.0/24"
+  vpc_id            = aws_vpc.Depi_vpc.id
+  cidr_block        = "10.0.4.0/24"
   tags = {
-    Name = "public-subnet-2"
-    Graduation_Project = "True"  
-    Task = "Amir Kasseb "
+    Name               = "public-subnet-2"
+    Graduation_Project = "True"
+    Task               = "Amir Kasseb "
   }
 }
 
 # Public Subnet 3
 resource "aws_subnet" "public-subnet-3" {
   availability_zone = "us-east-1c"
-  vpc_id     = aws_vpc.Depi_vpc.id
-  cidr_block = "10.0.5.0/24"
+  vpc_id            = aws_vpc.Depi_vpc.id
+  cidr_block        = "10.0.5.0/24"
   tags = {
-    Name = "pubic-subnet-3"
-    Graduation_Project = "True"  
-    Task = "Amir Kasseb "
+    Name               = "pubic-subnet-3"
+    Graduation_Project = "True"
+    Task               = "Amir Kasseb "
   }
 }
 
@@ -165,7 +150,7 @@ resource "aws_route_table_association" "public-association-3" {
 # Create Elastic ip for the nat-gateaway
 
 resource "aws_eip" "depi_nat_elasticip" {
-  domain = "vpc"   # Specify that the Elastic IP is for use in a VPC
+  domain = "vpc" # Specify that the Elastic IP is for use in a VPC
 }
 
 
@@ -225,8 +210,8 @@ resource "aws_route_table_association" "private-association-3" {
 resource "aws_security_group" "bastion_host_secuirty_group" {
   name        = "bastion_host_secuirty_group"
   description = "This security group is for bastion host"
-  vpc_id = aws_vpc.Depi_vpc.id 
-# Allowing SSH On bastion host 
+  vpc_id      = aws_vpc.Depi_vpc.id
+  # Allowing SSH On bastion host 
 
   ingress {
     from_port   = 22
@@ -236,7 +221,7 @@ resource "aws_security_group" "bastion_host_secuirty_group" {
   }
 
 
-# Allowing all outbounding traffic
+  # Allowing all outbounding traffic
 
   egress {
     from_port   = 0
@@ -249,11 +234,11 @@ resource "aws_security_group" "bastion_host_secuirty_group" {
 # Bastion host ec2 instance configuration
 
 resource "aws_instance" "depi-frontend-server" {
-  ami           = "ami-005fc0f236362e99f"
-  instance_type = "t2.micro"
-  key_name      =  aws_key_pair.amir-public-key.id
-  subnet_id = aws_subnet.public-subnet-1.id
-  vpc_security_group_ids  = [aws_security_group.private_app_secuirty_group.id]
+  ami                    = "ami-005fc0f236362e99f"
+  instance_type          = "t2.micro"
+  key_name               = aws_key_pair.abdelrahman-public-key.id
+  subnet_id              = aws_subnet.public-subnet-1.id
+  vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 
   tags = {
     Name = "depi-frontend-server"
@@ -264,9 +249,9 @@ resource "aws_instance" "depi-frontend-server" {
 resource "aws_security_group" "private_app_secuirty_group" {
   name        = "private_app_secuirty_group"
   description = "This security group is for private app"
-  vpc_id = aws_vpc.Depi_vpc.id 
+  vpc_id      = aws_vpc.Depi_vpc.id
 
-# Allowing SSH On private app 
+  # Allowing SSH On private app 
 
   ingress {
     from_port   = 22
@@ -276,7 +261,7 @@ resource "aws_security_group" "private_app_secuirty_group" {
   }
 
 
-# Allowing all outbounding traffic
+  # Allowing all outbounding traffic
 
   egress {
     from_port   = 0
@@ -289,11 +274,11 @@ resource "aws_security_group" "private_app_secuirty_group" {
 # jenkins server  instance configuration
 
 resource "aws_instance" "jenkins_server_instance" {
-  ami           = "ami-005fc0f236362e99f"
-  instance_type = "t2.micro"
-  key_name      =  aws_key_pair.amir-public-key.id
-  subnet_id = aws_subnet.public-subnet-3.id
-  vpc_security_group_ids  = [aws_security_group.private_app_secuirty_group.id]
+  ami                    = "ami-005fc0f236362e99f"
+  instance_type          = "t2.micro"
+  key_name               = aws_key_pair.abdelrahman-public-key.id
+  subnet_id              = aws_subnet.public-subnet-3.id
+  vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 
   tags = {
     Name = "jenkins_server_instance"
@@ -302,11 +287,11 @@ resource "aws_instance" "jenkins_server_instance" {
 # prometheus server  instance configuration
 
 resource "aws_instance" "depi_backend_server" {
-  ami           = "ami-005fc0f236362e99f"
-  instance_type = "t2.micro"
-  key_name      =  aws_key_pair.amir-public-key.id
-  subnet_id = aws_subnet.private-subnet-1.id
-  vpc_security_group_ids  = [aws_security_group.private_app_secuirty_group.id]
+  ami                    = "ami-005fc0f236362e99f"
+  instance_type          = "t2.micro"
+  key_name               = aws_key_pair.abdelrahman-public-key.id
+  subnet_id              = aws_subnet.private-subnet-1.id
+  vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 
   tags = {
     Name = "depi_backend_server"
@@ -317,27 +302,27 @@ resource "aws_instance" "depi_backend_server" {
 resource "aws_security_group" "rds_security_group" {
   name        = "rds-security-group"
   description = "Security group for RDS instance"
-  vpc_id = aws_vpc.Depi_vpc.id 
+  vpc_id      = aws_vpc.Depi_vpc.id
 
   ingress {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = ["10.0.1.0/24","10.0.2.0/24","10.0.3.0/24"]  # Allow port 3306 access from private subnet 1 ,2 ,3 
+    cidr_blocks = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"] # Allow port 3306 access from private subnet 1 ,2 ,3 
   }
 
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["10.0.1.0/24","10.0.2.0/24","10.0.3.0/24"]   # Allow ssh access from private subnet 1 , 2 , 3
+    cidr_blocks = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"] # Allow ssh access from private subnet 1 , 2 , 3
   }
 
   egress {
     from_port   = 0
     to_port     = 0
-    protocol    = "-1"           # Allow all outbound traffic
-    cidr_blocks = ["0.0.0.0/0"]  # To any destination
+    protocol    = "-1"          # Allow all outbound traffic
+    cidr_blocks = ["0.0.0.0/0"] # To any destination
   }
 
   tags = {
@@ -360,7 +345,7 @@ data "aws_secretsmanager_secret_version" "rds_secret_version" {
 # Create DB Subnet Group
 resource "aws_db_subnet_group" "rds-subnet-group" {
   name       = "rds-subnet-group"
-  subnet_ids = [aws_subnet.private-subnet-2.id,aws_subnet.private-subnet-3.id]
+  subnet_ids = [aws_subnet.private-subnet-2.id, aws_subnet.private-subnet-3.id]
   tags = {
     Name = "rds-subnet-group"
   }
@@ -369,43 +354,20 @@ resource "aws_db_subnet_group" "rds-subnet-group" {
 
 # RDS Instance
 resource "aws_db_instance" "depi-rds-instance" {
-  identifier              = "depi-rds-instance"
-  instance_class          = "db.t3.micro"
-  engine                  = "mysql"
-  engine_version          = "8.0"
-  allocated_storage       = 20
-  storage_type            = "gp2"
-  username                = jsondecode(data.aws_secretsmanager_secret_version.rds_secret_version.secret_string)["username"]
-  password                = jsondecode(data.aws_secretsmanager_secret_version.rds_secret_version.secret_string)["password"]
-  db_name                 = "RdsInstanceDatabase"
-  vpc_security_group_ids  = [aws_security_group.rds_security_group.id]
-  skip_final_snapshot     = true
-  db_subnet_group_name  = aws_db_subnet_group.rds-subnet-group.name
-  
-    tags = {
+  identifier             = "depi-rds-instance"
+  instance_class         = "db.t3.micro"
+  engine                 = "mysql"
+  engine_version         = "8.0"
+  allocated_storage      = 20
+  storage_type           = "gp2"
+  username               = jsondecode(data.aws_secretsmanager_secret_version.rds_secret_version.secret_string)["username"]
+  password               = jsondecode(data.aws_secretsmanager_secret_version.rds_secret_version.secret_string)["password"]
+  db_name                = "RdsInstanceDatabase"
+  vpc_security_group_ids = [aws_security_group.rds_security_group.id]
+  skip_final_snapshot    = true
+  db_subnet_group_name   = aws_db_subnet_group.rds-subnet-group.name
+
+  tags = {
     Name = "depi-rds-instance"
   }
 }
-
-
-# # Outputs
-# output "bastion_host_public_ip" {
-#   value = aws_instance.depi-frontend-server.public_ip
-#   description = "Public IP address of the bastion host instance"
-# }
-
-# # Private IP for the private instance
-# output "private_instance_private_ip" {
-#   value       = aws_instance.jenkins_server_instance.private_ip
-#   description = "Private IP of the private EC2 instance"
-# }
-
-output "rds_instance_endpoint" {
-  value = aws_db_instance.depi-rds-instance.endpoint
-  description = "Endpoint of the RDS instance"
-}
-
-# output "s3_bucket_name" {
-#   value = aws_s3_bucket.terraform_backend.bucket
-#   description = "Name of the S3 bucket used for Terraform state"
-# }

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,8 @@
 # AWS Provider Configuration
-
 provider "aws" {
   region = "us-east-1"
 }
-
+/*
 # Create an S3 bucket
 resource "aws_s3_bucket" "terraform_backend_2" {
   bucket = "espace-terraform-backend-2"
@@ -11,7 +10,7 @@ resource "aws_s3_bucket" "terraform_backend_2" {
     Name = "terraform-backend-2"
   }
 }
-
+*/
 # Create an AWS keypair
 resource "aws_key_pair" "ansible-public-key" {
   key_name   = "ansible-public-key"
@@ -27,6 +26,7 @@ resource "aws_vpc" "Depi_vpc" {
     Task               = "Amir Kasseb "
   }
 }
+
 # Create Private Subnets 
 
 # Private Subnet 1 
@@ -62,6 +62,7 @@ resource "aws_subnet" "private-subnet-3" {
     Task               = "Amir Kasseb "
   }
 }
+
 # Create Public Subnets 
 
 # Public Subnet 1 
@@ -102,7 +103,6 @@ resource "aws_subnet" "public-subnet-3" {
 }
 
 # Create Internet Gateway 
-
 resource "aws_internet_gateway" "depi_internet_gateway" {
   vpc_id = aws_vpc.Depi_vpc.id
 
@@ -112,7 +112,6 @@ resource "aws_internet_gateway" "depi_internet_gateway" {
 }
 
 # Create  route table  &  associate it to the public subnets 
-
 resource "aws_route_table" "internet-gateaway-routetable" {
   vpc_id = aws_vpc.Depi_vpc.id
 
@@ -120,7 +119,6 @@ resource "aws_route_table" "internet-gateaway-routetable" {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.depi_internet_gateway.id
   }
-
 
   tags = {
     Name = "internet-gateaway-routetable"
@@ -148,14 +146,11 @@ resource "aws_route_table_association" "public-association-3" {
 }
 
 # Create Elastic ip for the nat-gateaway
-
 resource "aws_eip" "depi_nat_elasticip" {
   domain = "vpc" # Specify that the Elastic IP is for use in a VPC
 }
 
-
 # Create Nat-Gateway & associate it to the private subnets 
-
 resource "aws_nat_gateway" "depi-nat-gateway" {
   allocation_id = aws_eip.depi_nat_elasticip.id
   subnet_id     = aws_subnet.public-subnet-2.id
@@ -170,7 +165,6 @@ resource "aws_nat_gateway" "depi-nat-gateway" {
 }
 
 # Create route table for private subnets 
-
 resource "aws_route_table" "nat-gateaway-routetable" {
   vpc_id = aws_vpc.Depi_vpc.id
 
@@ -178,7 +172,6 @@ resource "aws_route_table" "nat-gateaway-routetable" {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_nat_gateway.depi-nat-gateway.id
   }
-
 
   tags = {
     Name = "nat-gateaway-routetable"
@@ -206,13 +199,11 @@ resource "aws_route_table_association" "private-association-3" {
 }
 
 # Create the bastion host security group & bastion host ec2 instance
-
 resource "aws_security_group" "bastion_host_secuirty_group" {
   name        = "bastion_host_secuirty_group"
   description = "This security group is for bastion host"
   vpc_id      = aws_vpc.Depi_vpc.id
   # Allowing SSH On bastion host 
-
   ingress {
     from_port   = 22
     to_port     = 22
@@ -220,9 +211,7 @@ resource "aws_security_group" "bastion_host_secuirty_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-
   # Allowing all outbounding traffic
-
   egress {
     from_port   = 0
     to_port     = 0
@@ -232,7 +221,6 @@ resource "aws_security_group" "bastion_host_secuirty_group" {
 }
 
 # Bastion host ec2 instance configuration
-
 resource "aws_instance" "depi-frontend-server" {
   ami                    = "ami-005fc0f236362e99f"
   instance_type          = "t2.micro"
@@ -241,18 +229,22 @@ resource "aws_instance" "depi-frontend-server" {
   vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 
   tags = {
-    Name = "depi-frontend-server"
+    Name = "bastion"
+#    Service = ""
+#    Env = ""
+#    Role = ""
+#    Team = ""
+    Privacy = "public"
   }
 }
-# Create the private app security group & private app ec2 instance
 
+# Create the private app security group & private app ec2 instance
 resource "aws_security_group" "private_app_secuirty_group" {
   name        = "private_app_secuirty_group"
   description = "This security group is for private app"
   vpc_id      = aws_vpc.Depi_vpc.id
 
   # Allowing SSH On private app 
-
   ingress {
     from_port   = 22
     to_port     = 22
@@ -260,9 +252,7 @@ resource "aws_security_group" "private_app_secuirty_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-
   # Allowing all outbounding traffic
-
   egress {
     from_port   = 0
     to_port     = 0
@@ -271,8 +261,7 @@ resource "aws_security_group" "private_app_secuirty_group" {
   }
 }
 
-# jenkins server  instance configuration
-
+# jenkins server instance configuration
 resource "aws_instance" "jenkins_server_instance" {
   ami                    = "ami-005fc0f236362e99f"
   instance_type          = "t2.micro"
@@ -281,11 +270,16 @@ resource "aws_instance" "jenkins_server_instance" {
   vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 
   tags = {
-    Name = "jenkins_server_instance"
+    Name = "private-jenkins-server"
+#    Service = ""
+#    Env = ""
+#    Role = ""
+#    Team = ""
+    Privacy = "private"
   }
 }
-# prometheus server  instance configuration
 
+# prometheus server instance configuration
 resource "aws_instance" "depi_backend_server" {
   ami                    = "ami-005fc0f236362e99f"
   instance_type          = "t2.micro"
@@ -294,11 +288,16 @@ resource "aws_instance" "depi_backend_server" {
   vpc_security_group_ids = [aws_security_group.private_app_secuirty_group.id]
 
   tags = {
-    Name = "depi_backend_server"
+    Name = "private-backend-server"
+#    Service = ""
+#    Env = ""
+#    Role = ""
+#    Team = ""
+    Privacy = "private"
   }
 }
-# Security Group for RDS
 
+# Security Group for RDS
 resource "aws_security_group" "rds_security_group" {
   name        = "rds-security-group"
   description = "Security group for RDS instance"
@@ -328,11 +327,9 @@ resource "aws_security_group" "rds_security_group" {
   tags = {
     Name = "rds-security-group"
   }
-
 }
 
 # Create Secret & secret versions for Database credientials 
-
 data "aws_secretsmanager_secret" "rds_secret" {
   name = "RDS-Instance-SecretKey-v1"
 }
@@ -341,7 +338,6 @@ data "aws_secretsmanager_secret_version" "rds_secret_version" {
   secret_id = data.aws_secretsmanager_secret.rds_secret.id
 }
 
-
 # Create DB Subnet Group
 resource "aws_db_subnet_group" "rds-subnet-group" {
   name       = "rds-subnet-group"
@@ -349,7 +345,6 @@ resource "aws_db_subnet_group" "rds-subnet-group" {
   tags = {
     Name = "rds-subnet-group"
   }
-
 }
 
 # RDS Instance

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,17 +1,23 @@
 # Output declarations
 
+# Public IP for the Bastion host instance
 output "bastion_host_public_ip" {
   value       = aws_instance.depi-frontend-server.public_ip
   description = "Public IP address of the bastion host instance"
 }
 
-/*
-# Private IP for the private instance
-output "private_instance_private_ip" {
+# Private IP for the Jenkins server instance
+output "jenkins_server_private_ip" {
   value       = aws_instance.jenkins_server_instance.private_ip
   description = "Private IP of the private EC2 instance"
 }
-*/
+
+# Private IP for the backend server instance
+output "backend_server_private_ip" {
+  value       = aws_instance.depi_backend_server.private_ip
+  description = "Private IP of the private EC2 instance"
+}
+
 output "rds_instance_endpoint" {
   value       = aws_db_instance.depi-rds-instance.endpoint
   description = "Endpoint of the RDS instance"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,10 @@
 # Output declarations
-/*
+
 output "bastion_host_public_ip" {
   value       = aws_instance.depi-frontend-server.public_ip
   description = "Public IP address of the bastion host instance"
 }
-*/
+
 /*
 # Private IP for the private instance
 output "private_instance_private_ip" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,24 @@
+# Output declarations
+/*
+output "bastion_host_public_ip" {
+  value       = aws_instance.depi-frontend-server.public_ip
+  description = "Public IP address of the bastion host instance"
+}
+*/
+/*
+# Private IP for the private instance
+output "private_instance_private_ip" {
+  value       = aws_instance.jenkins_server_instance.private_ip
+  description = "Private IP of the private EC2 instance"
+}
+*/
+output "rds_instance_endpoint" {
+  value       = aws_db_instance.depi-rds-instance.endpoint
+  description = "Endpoint of the RDS instance"
+}
+/*
+output "s3_bucket_name" {
+  value       = aws_s3_bucket.terraform_backend.bucket
+  description = "Name of the S3 bucket used for Terraform state"
+}
+*/

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,16 @@
+# Terraform Configuration
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  /*
+  backend "s3" {
+    bucket = "espace-terraform-backend-2"
+    key    = "Terraform-Backend/terraform.tfstate"
+    region = "us-eas-1"
+  }
+  */
+}


### PR DESCRIPTION
# Added Ansible playbooks to manage the EC2 instances.
- Created a playbook to install **Docker Engine** on all private instances.
- Created a playbook to download **Jenkins image** and run a **Jenkins container** on the Jenkins Host (_Master Node_).
- Created a playbook to install **Java** on the Backend Host (_Worker Node_).
- Implemented **Ansible roles** to simplify the playbooks.
- Implemented a **dynamic** Ansible inventory using the `aws_ec2` Ansible plugin for better automation and scalability.
- Disabled `host_key_checking` for Ansible to automate SSH connection to the EC2 instances.
- Added `jenkins_masters` and `jenkins_workers` groups in the dynamic inventory.
- Added a bootstrap playbook to manage updating packages on the EC2 instances and to change their host names.
- Fixed `jenkins_home` directory's mode.
- Added tasks to facilitate preparing the Jenkins worker nodes.
- Added `helper_steps.txt` to guide users.

# Updated Terraform files to support Ansible integration.
- Added `terraform.tf` and `outputs.tf` to simplify `main.tf`.
- Fixed the `subnet_id` of the `jenkins_server_instance`.
- Added `.terraform.lock.hcl` to VCS for better version consistency.
- Added EC2 tags to support a dynamic Ansible inventory and to reduce conflicts with other teams' running EC2 instances.
- Added an ingress rule to `private_app_security_group` to allow access to the Jenkins Server.
- Fixed `bastion`'s security group.
- Improved ingress rules for `private_app_security_group`.
- Added `Jenkins` tag to the private instances.
- Added an output for `backend_server`'s private IP.